### PR TITLE
Add gsettings-desktop-schemas-dev

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,6 +87,7 @@ parts:
     - libavutil-dev
     - libswscale-dev
     # - glslang-tools
+    - gsettings-desktop-schemas-dev
     stage-packages:
     - libsdl2-2.0-0
     - libxi6


### PR DESCRIPTION
As mentioned in #33, the snap crashes after selecting folder/file.

It seems that simply this package is missing in the build. However: I DID NOT TRY THIS PATCH YET, but I guess it should do the trick